### PR TITLE
Add support for Late mods and specify modloader

### DIFF
--- a/QuestPatcher.QMod/ModLoader.cs
+++ b/QuestPatcher.QMod/ModLoader.cs
@@ -1,0 +1,8 @@
+namespace QuestPatcher.QMod
+{
+    public enum ModLoader
+    {
+        QuestLoader,
+        Scotland2
+    }
+}

--- a/QuestPatcher.QMod/ModLoaderJsonConverter.cs
+++ b/QuestPatcher.QMod/ModLoaderJsonConverter.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace QuestPatcher.QMod
+{
+    public class ModLoaderJsonConverter : JsonConverter<ModLoader>
+    {
+        public override ModLoader Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                if (Enum.TryParse(reader.GetString(), out ModLoader modLoader))
+                {
+                    return modLoader;
+                }
+            }
+
+            throw new JsonException($"Unable to convert '{reader.GetString()}' to ModLoader enum.");
+        }
+
+        public override void Write(Utf8JsonWriter writer, ModLoader value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.ToString());
+        }
+    }
+}

--- a/QuestPatcher.QMod/QMod.cs
+++ b/QuestPatcher.QMod/QMod.cs
@@ -73,22 +73,8 @@ namespace QuestPatcher.QMod
         /// </summary>
         public ModLoader ModLoader
         {
-            get
-            {
-                switch(_manifest.ModLoader)
-                {
-                    case "QuestLoader":
-                        return QuestPatcher.QMod.ModLoader.QuestLoader;
-                    case "Scotland2":
-                        return QuestPatcher.QMod.ModLoader.Scotland2;
-                    default:
-                        return QuestPatcher.QMod.ModLoader.QuestLoader;
-                }
-            }
-            set {
-                
-                SetValue<string>(_manifest.ModLoader, Enum.GetName(typeof(QuestPatcher.QMod.ModLoader), value), v => _manifest.ModLoader = v);
-            }
+            get => _manifest.ModLoader;
+            set => SetValue(_manifest.ModLoader, ModLoader, v => _manifest.ModLoader = v);
         }
 
         /// <summary>

--- a/QuestPatcher.QMod/QMod.cs
+++ b/QuestPatcher.QMod/QMod.cs
@@ -71,7 +71,7 @@ namespace QuestPatcher.QMod
         /// The modloader this mod uses
         /// If none is specified QuestLoader is returned
         /// </summary>
-        public ModLoader? ModLoader
+        public ModLoader ModLoader
         {
             get
             {

--- a/QuestPatcher.QMod/QMod.cs
+++ b/QuestPatcher.QMod/QMod.cs
@@ -68,6 +68,30 @@ namespace QuestPatcher.QMod
         public string? PackageVersion { get => _manifest.PackageVersion; set => SetValue(_manifest.PackageVersion, value, v => _manifest.PackageVersion = v); }
 
         /// <summary>
+        /// The modloader this mod uses
+        /// If none is specified QuestLoader is returned
+        /// </summary>
+        public ModLoader? ModLoader
+        {
+            get
+            {
+                switch(_manifest.ModLoader)
+                {
+                    case "QuestLoader":
+                        return QuestPatcher.QMod.ModLoader.QuestLoader;
+                    case "Scotland2":
+                        return QuestPatcher.QMod.ModLoader.Scotland2;
+                    default:
+                        return QuestPatcher.QMod.ModLoader.QuestLoader;
+                }
+            }
+            set {
+                
+                SetValue<string>(_manifest.ModLoader, Enum.GetName(typeof(QuestPatcher.QMod.ModLoader), value), v => _manifest.ModLoader = v);
+            }
+        }
+
+        /// <summary>
         /// Whether or not the mod is a library mod.
         /// Library mods should be automatically uninstalled whenever no mods that depend on them are installed
         /// </summary>
@@ -77,6 +101,11 @@ namespace QuestPatcher.QMod
         /// Files copied to the mod loader's mods directory
         /// </summary>
         public IReadOnlyList<string> ModFileNames => _manifest.ModFileNames;
+        
+        /// <summary>
+        /// Files copied to the mod loader's mods directory
+        /// </summary>
+        public IReadOnlyList<string> LateModFileNames => _manifest.LateModFileNames;
 
         /// <summary>
         /// Files copied to the mod loader's libraries directory.

--- a/QuestPatcher.QMod/QModManifest.cs
+++ b/QuestPatcher.QMod/QModManifest.cs
@@ -84,13 +84,26 @@ namespace QuestPatcher.QMod
         /// Library mods should be automatically uninstalled whenever no mods that depend on them are installed
         /// </summary>
         public bool IsLibrary { get; set; }
+        
+        /// <summary>
+        /// Modloader this mod is made for. Either of 'QuestLoader' or 'Scotland2'
+        /// </summary>
+        [JsonPropertyName("modloader")]
+        public string ModLoader { get; set; }
 
         /// <summary>
-        /// Files copied to the mod loader's mods directory
+        /// Files copied to the mod loader's early mods directory
         /// </summary>
         [JsonPropertyName("modFiles")]
         public List<string> ModFileNames { get; set; } = new List<string>();
 
+
+        /// <summary>
+        /// Files copied to the mod loader's late mods directory
+        /// </summary>
+        [JsonPropertyName("lateModFiles")]
+        public List<string> LateModFileNames { get; set; } = new List<string>();
+        
         /// <summary>
         /// Files copied to the mod loader's libraries directory.
         /// Ideally, when uninstalling mods, these files should only be removed if no other installed/enabled mod has a library with the same name.

--- a/QuestPatcher.QMod/QModManifest.cs
+++ b/QuestPatcher.QMod/QModManifest.cs
@@ -84,13 +84,13 @@ namespace QuestPatcher.QMod
         /// Library mods should be automatically uninstalled whenever no mods that depend on them are installed
         /// </summary>
         public bool IsLibrary { get; set; }
-        
+
         /// <summary>
         /// Modloader this mod is made for. Either of 'QuestLoader' or 'Scotland2'
         /// </summary>
         [JsonPropertyName("modloader")]
         [JsonConverter(typeof(ModLoaderJsonConverter))]
-        public ModLoader ModLoader { get; set; }
+        public ModLoader ModLoader { get; set; } = ModLoader.QuestLoader;
 
         /// <summary>
         /// Files copied to the mod loader's early mods directory

--- a/QuestPatcher.QMod/QModManifest.cs
+++ b/QuestPatcher.QMod/QModManifest.cs
@@ -89,7 +89,8 @@ namespace QuestPatcher.QMod
         /// Modloader this mod is made for. Either of 'QuestLoader' or 'Scotland2'
         /// </summary>
         [JsonPropertyName("modloader")]
-        public string ModLoader { get; set; }
+        [JsonConverter(typeof(ModLoaderJsonConverter))]
+        public ModLoader ModLoader { get; set; }
 
         /// <summary>
         /// Files copied to the mod loader's early mods directory

--- a/QuestPatcher.QMod/Resources/qmod.schema.json
+++ b/QuestPatcher.QMod/Resources/qmod.schema.json
@@ -49,6 +49,7 @@
   ],
   "anyOf": [
     { "required": [ "modFiles" ] },
+    { "required": [ "lateModFiles" ] },
     { "required": [ "libraryFiles" ] },
     { "required": [ "dependencies" ] },
     { "required": [ "fileCopies" ] }
@@ -62,12 +63,13 @@
         "0.1.0",
         "0.1.1",
         "0.1.2",
-        "1.0.0"
+        "1.0.0",
+        "1.0.1"
       ],
       "default": "",
-      "description": "The version of the schema to use for QuestPatcher. Must be 0.1.0, 0.1.1, 0.1.2 or 1.0.0",
+      "description": "The version of the schema to use for QuestPatcher. Must be 0.1.0, 0.1.1, 0.1.2, 1.0.0, 1.0.1",
       "examples": [
-        "1.0.0"
+        "1.0.1"
       ],
       "title": "Schema Version",
       "type": "string"
@@ -164,6 +166,20 @@
       "title": "Mod cover image",
       "type": "string"
     },
+    "modloader": {
+      "$id": "#/properties/modloader",
+      "enum": [
+        "QuestLoader",
+        "Scotland2"
+      ],
+      "default": "QuestLoader",
+      "description": "The modloader that this mod is for. If not specified, this mod is for QuestLoader because of backwards compatibility.",
+      "examples": [
+        "Scotland2"
+      ],
+      "title": "Modloader",
+      "type": "string"
+    },
     "modFiles": {
       "$id": "#/properties/modFiles",
       "default": [],
@@ -183,6 +199,30 @@
         "title": "Mod File",
         "default": "",
         "description": "A file to install as a mod.",
+        "examples": [
+          "libexample-mod-2.so"
+        ]
+      }
+    },
+    "lateModFiles": {
+      "$id": "#/properties/lateModFiles",
+      "default": [],
+      "description": "The files to install as late mods.",
+      "examples": [
+        [
+          "libexample-mod-2.so"
+        ]
+      ],
+      "title": "Late Mod Files",
+      "uniqueItems": true,
+      "type": "array",
+      "additionalItems": true,
+      "items": {
+        "$id": "#/properties/lateModFiles/items",
+        "type": "string",
+        "title": "Late Mod File",
+        "default": "",
+        "description": "A file to install as a late mod.",
         "examples": [
           "libexample-mod-2.so"
         ]


### PR DESCRIPTION
# Changes to the format
## `modloader`
- any of `Scotland2`, `QuestLoader`
- default: `QuestLoader`
- Used so Mod Managers can install mods to the correct modloader directory

## `lateModFiles`
- List of file names just like `modFiles` and `libraryFiles`
- Used for late mods of Scotland2 (`mods` directory), `modFiles` will be for `earlyMods`