### PR TITLE
Proposal: Manifest prefix

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -12,3 +12,15 @@ The below are strong suggestions for the values of certain properties in the `mo
 
 - Strings in the `modFiles`, `lateModFiles` and `libraryFiles` lists SHOULD be full name of an entry in the ZIP.
 - The `name` property of objects in the `fileCopies` list SHOULD be the full name of an entry in the ZIP.
+
+## Format Extensions
+### Manifest Prefix
+
+The manifest prefix is a prefix to the QMOD's ZIP archive containing the contents of the `mod.json`. It allows an installer to read the `mod.json` before the QMOD has been fully downloaded.
+
+
+A manifest-prefixed QMOD (MQ) has the following requirements (all values given are little-endian):
+- An MQ MUST be a valid QMOD.
+- An MQ MUST start with the prefix `0x1D83B1DB` (4 bytes).
+- The next 4 bytes MUST contain the uncompressed length of the `mod.json` file, in bytes.
+- This data MUST be suffixed with the full, **uncompressed** contents of the `mod.json` entry within the QMOD.


### PR DESCRIPTION
The manifest prefix is an extension to the QMOD format that prefixes the QMOD file with the uncompressed contents of the `mod.json` file. This is to allow a mod installer to build a dependency tree without fully downloading each mod, which will mean that dependency conflicts can be warned of much earlier in the installation process.

Reading this prefix is entirely optional, as any ZIP file can be prefixed with any arbitrary data and still remain valid, so long as the central directory is updated appropriately when saving.

The prefix specification is copied below.

### Manifest Prefix

The manifest prefix is a prefix to the QMOD's ZIP archive containing the contents of the `mod.json`. It allows an installer to read the `mod.json` before the QMOD has been fully downloaded.


A manifest-prefixed QMOD (MQ) has the following requirements (all values given are little-endian):
- An MQ MUST be a valid QMOD.
- An MQ MUST start with the prefix `0x1D83B1DB` (4 bytes).
- The next 4 bytes MUST contain the uncompressed length of the `mod.json` file, in bytes, as in the local file header/central directory header for the mod.json file. (little-endian)
- This data MUST be suffixed with the full, **uncompressed** contents of the `mod.json` entry within the QMOD.