### PR TITLE
QMOD Version 1.2.0: Add support for optional dependencies

### DIFF
--- a/QuestPatcher.QMod.Tests/ManifestLoadTests.cs
+++ b/QuestPatcher.QMod.Tests/ManifestLoadTests.cs
@@ -29,11 +29,17 @@ namespace QuestPatcher.QMod.Tests
 
             Assert.Equal(ModLoader.Scotland2, manifest.ModLoader);
 
-            Assert.Single(manifest.Dependencies);
-            Dependency dependency = manifest.Dependencies[0];
-            Assert.Equal("my-dependency", dependency.Id);
-            Assert.Equal("^0.1.0", dependency.VersionRangeString);
-            Assert.Equal("https://somesite.com/my_dependency_0_1_0.qmod", dependency.DownloadUrlString);
+            Assert.Equal(2, manifest.Dependencies.Count);
+            Dependency requiredDependency = manifest.Dependencies[0];
+            Assert.Equal("my-dependency", requiredDependency.Id);
+            Assert.Equal("^0.1.0", requiredDependency.VersionRangeString);
+            Assert.Equal("https://somesite.com/my_dependency_0_1_0.qmod", requiredDependency.DownloadUrlString);
+            Assert.True(requiredDependency.Required);
+            Dependency optionalDependency = manifest.Dependencies[1];
+            Assert.Equal("my-optional-dependency", optionalDependency.Id);
+            Assert.Equal("^0.1.0", optionalDependency.VersionRangeString);
+            Assert.Equal("https://somesite.com/my_optional_dependency_0_1_0.qmod", optionalDependency.DownloadUrlString);
+            Assert.False(optionalDependency.Required);
 
             Assert.Single(manifest.FileCopies);
             FileCopy fileCopy = manifest.FileCopies[0];

--- a/QuestPatcher.QMod.Tests/Resources/exampleMod.json
+++ b/QuestPatcher.QMod.Tests/Resources/exampleMod.json
@@ -1,5 +1,5 @@
 ﻿{
-  "_QPVersion": "1.1.0",
+  "_QPVersion": "1.2.0",
   "name": "ExampleMod",
   "id": "example-mod",
   "author": "Lauriethefish",
@@ -25,6 +25,12 @@
       "id": "my-dependency",
       "version": "^0.1.0",
       "downloadIfMissing": "https://somesite.com/my_dependency_0_1_0.qmod"
+    },
+    {
+      "id": "my-optional-dependency",
+      "version": "^0.1.0",
+      "downloadIfMissing": "https://somesite.com/my_optional_dependency_0_1_0.qmod",
+      "required": false
     }
   ],
   "fileCopies": [

--- a/QuestPatcher.QMod.Tests/Resources/invalidMod.json
+++ b/QuestPatcher.QMod.Tests/Resources/invalidMod.json
@@ -1,5 +1,5 @@
 ﻿{
-  "_QPVersion": "1.1.0",
+  "_QPVersion": "1.2.0",
   "name": "ExampleMod",
   "id": "example-mod",
   "version": "2.0.0",

--- a/QuestPatcher.QMod.Tests/Resources/noModloader.json
+++ b/QuestPatcher.QMod.Tests/Resources/noModloader.json
@@ -1,5 +1,5 @@
 ﻿{
-  "_QPVersion": "1.1.0",
+  "_QPVersion": "1.2.0",
   "name": "ExampleMod",
   "id": "example-mod",
   "author": "Joe",

--- a/QuestPatcher.QMod/Dependency.cs
+++ b/QuestPatcher.QMod/Dependency.cs
@@ -40,6 +40,9 @@ namespace QuestPatcher.QMod
             set => VersionRange = Range.Parse(value);
         }
 
+        [JsonPropertyName("required")]
+        public bool Required { get; set; }
+
         /// <summary>
         /// Supported version range of the dependency. Installers should check that if the dependency is installed, it is within this range.
         ///
@@ -83,11 +86,16 @@ namespace QuestPatcher.QMod
         /// <param name="id">The ID of the mod depended on, must not contain whitespace</param>
         /// <param name="versionRangeString">The semver version range of supported versions of the mod</param>
         /// <param name="downloadUrlString">The URL to download the dependency from if it is not installed, null for none (default)</param>
-        public Dependency(string id, string versionRangeString = "*", string? downloadUrlString = null)
+        /// <param name="required">If true, then this dependency must be installed within the correct version range for the mod to be installed.
+        /// If false, then:
+        /// - If the dependency is not installed, this mod can install with no further checks.
+        /// - If the dependency is installed, it MUST be within the specified version range and the installer should attempt to upgrade it if necessary.</param>
+        public Dependency(string id, string versionRangeString = "*", string? downloadUrlString = null, bool required = true)
         {
             Id = id;
             VersionRangeString = versionRangeString;
             DownloadUrlString = downloadUrlString;
+            Required = required;
             
             // _id has been set by assigning the property.
             // We don't just assign the field directly as we need to check that the ID string is valid using the property setter

--- a/QuestPatcher.QMod/QModManifest.cs
+++ b/QuestPatcher.QMod/QModManifest.cs
@@ -157,7 +157,8 @@ namespace QuestPatcher.QMod
             "0.1.1",
             "0.1.2",
             "1.0.0",
-            "1.1.0"
+            "1.1.0",
+            "1.2.0"
         }.ToHashSet();
 
         private const string LatestSchemaVersion = "1.0.0";

--- a/QuestPatcher.QMod/Resources/qmod.schema.json
+++ b/QuestPatcher.QMod/Resources/qmod.schema.json
@@ -5,7 +5,7 @@
   "description": "A mod of the format described by QuestPatcher.",
   "examples": [
     {
-      "_QPVersion": "1.1.0",
+      "_QPVersion": "1.2.0",
       "name": "ExampleMod2",
       "id": "example-mod-2",
       "author": "Lauriethefish#6700",
@@ -64,12 +64,13 @@
         "0.1.1",
         "0.1.2",
         "1.0.0",
-        "1.1.0"
+        "1.1.0",
+        "1.2.0"
       ],
       "default": "",
-      "description": "The version of the schema to use for QuestPatcher. Must be 0.1.0, 0.1.1, 0.1.2, 1.0.0, or 1.1.0",
+      "description": "The version of the schema to use for QuestPatcher. Must be 0.1.0, 0.1.1, 0.1.2, 1.0.0, 1.1.0 or 1.2.0",
       "examples": [
-        "1.1.0"
+        "1.2.0"
       ],
       "title": "Schema Version",
       "type": "string"
@@ -316,6 +317,17 @@
             "pattern": "https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()@:%_\\+.~#?&//=]*)",
             "examples": [
               "https://somesite.com/my_dependency_0_1_0.qmod"
+            ]
+          },
+          "required": {
+            "$id": "#/properties/dependencies/items/properties/required",
+            "type": "boolean",
+            "title": "Required",
+            "description": "Whether the dependency must be installed for the mod to work. Optional dependencies will not be installed automatically if they are missing, but if they are installed, the installer MUST verify that the version matches the specified version range.",
+            "default": true,
+            "examples": [
+              true,
+              false
             ]
           }
         },


### PR DESCRIPTION
This pull request adds support for optional dependencies within a qmod. To create an optional dependency, specify `"required": false` in the dependency object in the qmod file.

If an installer encounters an optional dependency, it should check if the dependency is installed. If it is not installed, the installer does nothing, but if the dependency is installed, the installer should check the version range (`version` property) to see if the version is a match. If it is not, the installer should attempt to upgrade the dependency if possible, otherwise it should refuse to install the mod.

Currently, [ModsBeforeFriday](https://mbf.bsquest.xyz/) supports this property, but it should be added to the schema proper so it can get wider support. I am open to suggestions if others believe this functionality should be specified differently.

